### PR TITLE
Fixed URL in curl command to get the GPG key for Debian repo

### DIFF
--- a/content/en/repo/stable/_index.md
+++ b/content/en/repo/stable/_index.md
@@ -54,7 +54,7 @@ Those packages will be migrated to [OBS](https://build.opensuse.org/repositories
 ### GPG Key (one-time setup)
 
 ```bash
-curl -fsS "https://labs.consol.de/repo/stable/GPG-KEY-4096" -o /etc/apt/trusted.gpg.d/monitoring-repo-consol-de-gpg-2026.asc
+curl -fsS "https://labs.consol.de/repo/stable/monitoring-repo-consol-de-gpg-2026.asc" -o /etc/apt/trusted.gpg.d/monitoring-repo-consol-de-gpg-2026.asc
 ```
 
 ### Debian Bookworm (12.0)

--- a/content/en/repo/stream/_index.md
+++ b/content/en/repo/stream/_index.md
@@ -54,7 +54,7 @@ Those packages will be migrated to [OBS](https://build.opensuse.org/repositories
 ### GPG Key (one-time setup)
 
 ```bash
-curl -fsS "https://labs.consol.de/repo/stable/GPG-KEY-4096" -o /etc/apt/trusted.gpg.d/monitoring-repo-consol-de-gpg-2026.asc
+curl -fsS "https://labs.consol.de/repo/stable/monitoring-repo-consol-de-gpg-2026.asc" -o /etc/apt/trusted.gpg.d/monitoring-repo-consol-de-gpg-2026.asc
 ```
 
 ### Debian Bookworm (12.0)


### PR DESCRIPTION
Fixed the source URL for the new GPG key, which wasn't updated in the previous commit.